### PR TITLE
Fix parameter type handling

### DIFF
--- a/app/availability/[departement]/page.tsx
+++ b/app/availability/[departement]/page.tsx
@@ -23,8 +23,8 @@ interface TeamMember {
   calendarId?: string;
 }
 
-// Type des paramètres pour Next.js 15
-type ParamsType = Promise<{ departement: string }>;
+// Type de paramètre du segment dynamique
+type ParamsType = { departement: string };
 
 export default function EmployeeAvailabilityPage({
   params,

--- a/app/team/[department]/page.tsx
+++ b/app/team/[department]/page.tsx
@@ -14,17 +14,16 @@ const departmentNames: Record<string, string> = {
   'ventes': 'Ventes'
 };
 
-// Définir le type des paramètres comme une Promise pour Next.js 15
-type ParamsType = Promise<{ department: string }>;
+// Type correct des paramètres du segment dynamique
+type ParamsType = { department: string };
 
 // Suivre le modèle de Next.js 15 pour les composants de page
-export default async function Page({
+export default function Page({
   params,
 }: {
   params: ParamsType
 }) {
-  // Attend la résolution de la Promise params
-  const { department } = await params;
+  const { department } = params;
   
   // Récupérer le nom d'affichage correct avec accents si disponible
   const normalizedDept = normalizeString(department);


### PR DESCRIPTION
## Summary
- correct dynamic segment params types in team and availability pages

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next/server')*