### PR TITLE
Fix timezone and docs; add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ First, run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/app/api/google/availability/route.ts
+++ b/app/api/google/availability/route.ts
@@ -3,7 +3,7 @@ import { getAvailableTimeSlots } from '@/lib/googleCalendar';
 
 export async function POST(request: Request) {
   try {
-    const { calendarId, startDate, endDate, timeZone = '/Paris', duration = 30 } = await request.json();
+    const { calendarId, startDate, endDate, timeZone = 'Europe/Paris', duration = 30 } = await request.json();
     
     if (!calendarId || !startDate || !endDate) {
       return NextResponse.json({ 

--- a/lib/__tests__/googleCalendar.test.ts
+++ b/lib/__tests__/googleCalendar.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { isSlotAvailable } from '../googleCalendar'
+
+describe('isSlotAvailable', () => {
+  it('returns true when slot does not overlap busy times', () => {
+    const busy = [
+      { start: new Date('2025-05-16T10:00:00'), end: new Date('2025-05-16T10:30:00') }
+    ]
+    const result = isSlotAvailable(
+      new Date('2025-05-16T09:00:00'),
+      new Date('2025-05-16T09:30:00'),
+      busy
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false when slot overlaps busy time', () => {
+    const busy = [
+      { start: new Date('2025-05-16T09:15:00'), end: new Date('2025-05-16T09:45:00') }
+    ]
+    const result = isSlotAvailable(
+      new Date('2025-05-16T09:00:00'),
+      new Date('2025-05-16T09:30:00'),
+      busy
+    )
+    expect(result).toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.2",
@@ -36,6 +37,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- correct misuse of timezone info when creating events
- fix comment typo in google calendar helper
- use valid default timezone
- align README instructions
- add initial vitest test for slot availability

## Testing
- `npm test` *(fails: vitest not found)*