### PR TITLE
Fix timezone handling in availability generator

### DIFF
--- a/lib/googleCalendar.ts
+++ b/lib/googleCalendar.ts
@@ -245,7 +245,7 @@ export const createCalendarEvent = async (
 export const generateAvailableTimeSlots = (
   startDate: Date,
   endDate: Date,
-  busyTimes: Array<{ start: string, end: string }>,
+  busyTimes: Array<{ start: string; end: string }>,
   durationMinutes: number = 30,
   timeZone: string = 'America/Montreal'
 ) => {
@@ -266,37 +266,39 @@ export const generateAvailableTimeSlots = (
   }
   
   const slots = [];
-  const currentDate = new Date(startDate);
+
+  // Fonction utilitaire pour obtenir l'offset en millisecondes pour une date dans un fuseau horaire
+  const getOffsetMs = (date: Date) => {
+    return date.getTime() - new Date(date.toLocaleString('en-US', { timeZone })).getTime();
+  };
+
+  // Normaliser les bornes au début de la journée UTC
+  const currentDate = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate()));
+  const endDateUTC = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate()));
   
-  // Calculer le décalage horaire entre UTC et le fuseau souhaité pour compensation
-  // Ceci est crucial pour garantir que les heures sont correctes dans le fuseau de l'utilisateur
-  const userTZOffset = startDate.getTimezoneOffset() * 60000; // en millisecondes
-  console.log(`Décalage du fuseau horaire local: ${userTZOffset / 3600000} heures`);
-  
-  while (currentDate < endDate) {
+  while (currentDate <= endDateUTC) {
+    const offsetMs = getOffsetMs(currentDate);
+    const dayBaseUTC = Date.UTC(
+      currentDate.getUTCFullYear(),
+      currentDate.getUTCMonth(),
+      currentDate.getUTCDate()
+    ) + offsetMs;
+
+    // Déterminer le jour de la semaine dans le fuseau ciblé
+    const localDay = new Date(dayBaseUTC + 12 * 3600000).getUTCDay();
+
     // Ignorer les weekends
-    if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6) {
-      // Heures de travail : 9h-12h et 14h-17h
-      const workingHours = [
-        { start: 9, end: 12 },
-        { start: 14, end: 17 }
-      ];
-      
-      for (const period of workingHours) {
-        console.log(`Génération des créneaux pour la période ${period.start}h-${period.end}h le ${currentDate.toLocaleDateString()}`);
-        for (let hour = period.start; hour < period.end; hour++) {
-          for (let minute = 0; minute < 60; minute += durationMinutes) {
-            // Créer une date pour ce créneau
-            const slotStart = new Date(currentDate);
-            slotStart.setHours(hour, minute, 0, 0);
-            
-            const slotEnd = new Date(slotStart);
-            slotEnd.setMinutes(slotStart.getMinutes() + durationMinutes);
-            
-            // Ne pas dépasser l'heure de fin de période
-            if ((hour === period.end - 1) && (minute + durationMinutes > 60)) {
-              continue;
-            }
+    if (localDay !== 0 && localDay !== 6) {
+      // Heures de travail continues de 9h à 17h
+      for (let hour = 9; hour < 17; hour++) {
+        for (let minute = 0; minute < 60; minute += durationMinutes) {
+          const slotStart = new Date(dayBaseUTC + hour * 3600000 + minute * 60000);
+          const slotEnd = new Date(slotStart.getTime() + durationMinutes * 60000);
+
+          // Ne pas dépasser 17h
+          if (slotEnd.getTime() > dayBaseUTC + 17 * 3600000) {
+            continue;
+          }
             
             // Formatage explicite des heures pour l'API Google sans conversion UTC
             const slotStartISO = formatDateWithoutConversion(slotStart);
@@ -304,7 +306,7 @@ export const generateAvailableTimeSlots = (
             
             // Vérifier si le créneau est disponible (non occupé)
             if (isSlotAvailable(slotStart, slotEnd, busyTimesParsed)) {
-              const formattedTime = formatDateRange(slotStart, slotEnd);
+              const formattedTime = formatDateRange(slotStart, slotEnd, 'fr-FR', timeZone);
               console.log(`Créneau disponible trouvé: ${formattedTime}`);
               
               slots.push({
@@ -324,8 +326,8 @@ export const generateAvailableTimeSlots = (
     }
     
     // Passer au jour suivant
-    currentDate.setDate(currentDate.getDate() + 1);
-    currentDate.setHours(0, 0, 0, 0);
+    currentDate.setUTCDate(currentDate.getUTCDate() + 1);
+    currentDate.setUTCHours(0, 0, 0, 0);
   }
   
   console.log(`Nombre total de créneaux disponibles générés: ${slots.length}`);
@@ -339,15 +341,8 @@ export const generateAvailableTimeSlots = (
 
 // Format une date sans conversion en UTC
 function formatDateWithoutConversion(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-  
-  // Format RFC 3339 sans 'Z' à la fin
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  // Utiliser l'ISO standard avec le "Z" final pour conserver l'instant précis
+  return date.toISOString();
 }
 
 // Vérifier si un créneau horaire est disponible
@@ -377,23 +372,31 @@ export const isSlotAvailable = (
 };
 
 // Formatter une plage de dates pour l'affichage
-export const formatDateRange = (start: Date, end: Date, locale: string = 'fr-FR') => {
-  const formattedDate = start.toLocaleDateString(locale, { 
-    day: 'numeric', 
-    month: 'long', 
-    year: 'numeric' 
+export const formatDateRange = (
+  start: Date,
+  end: Date,
+  locale: string = 'fr-FR',
+  timeZone: string = 'America/Montreal'
+) => {
+  const formattedDate = start.toLocaleDateString(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone,
   });
-  
-  const formattedStartTime = start.toLocaleTimeString(locale, { 
-    hour: '2-digit', 
-    minute: '2-digit' 
+
+  const formattedStartTime = start.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone,
   });
-  
-  const formattedEndTime = end.toLocaleTimeString(locale, { 
-    hour: '2-digit', 
-    minute: '2-digit' 
+
+  const formattedEndTime = end.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone,
   });
-  
+
   return `${formattedDate} — ${formattedStartTime} - ${formattedEndTime}`;
 };
 
@@ -405,49 +408,49 @@ export const generateMockTimeSlots = (
   timeZone: string = 'America/Montreal'
 ) => {
   const slots = [];
-  const currentDate = new Date(startDate);
-  
-  while (currentDate < endDate) {
-    // Ignorer les weekends
-    if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6) {
-      // Heures de travail : 9h-12h et 14h-17h
+
+  const getOffsetMs = (date: Date) => {
+    return date.getTime() - new Date(date.toLocaleString('en-US', { timeZone })).getTime();
+  };
+
+  const currentDate = new Date(Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate()));
+  const endDateUTC = new Date(Date.UTC(endDate.getUTCFullYear(), endDate.getUTCMonth(), endDate.getUTCDate()));
+
+  while (currentDate <= endDateUTC) {
+    const offsetMs = getOffsetMs(currentDate);
+    const dayBaseUTC = Date.UTC(
+      currentDate.getUTCFullYear(),
+      currentDate.getUTCMonth(),
+      currentDate.getUTCDate()
+    ) + offsetMs;
+
+    const localDay = new Date(dayBaseUTC + 12 * 3600000).getUTCDay();
+
+    if (localDay !== 0 && localDay !== 6) {
       for (let hour = 9; hour < 17; hour++) {
-        // Sauter la pause déjeuner
-        if (hour >= 12 && hour < 14) continue;
-        
-        // Pour chaque heure, générer des créneaux de la durée spécifiée
         for (let minute = 0; minute < 60; minute += durationMinutes) {
-          const slotStart = new Date(currentDate);
-          slotStart.setHours(hour, minute, 0, 0);
-          
-          const slotEnd = new Date(slotStart);
-          slotEnd.setMinutes(slotStart.getMinutes() + durationMinutes);
-          
-          // Ne pas dépasser l'heure de fin de journée
-          if ((hour === 11 && minute + durationMinutes > 60) || 
-              (hour === 16 && minute + durationMinutes > 60) ||
-              slotEnd > endDate) {
+          const slotStart = new Date(dayBaseUTC + hour * 3600000 + minute * 60000);
+          const slotEnd = new Date(slotStart.getTime() + durationMinutes * 60000);
+
+          if (slotEnd.getTime() > dayBaseUTC + 17 * 3600000) {
             continue;
           }
-          
-          // Simuler des indisponibilités aléatoires (30% des créneaux sont occupés)
+
           if (Math.random() > 0.3) {
             slots.push({
               id: `slot-${slotStart.getTime()}`,
               start: slotStart.toISOString(),
               end: slotEnd.toISOString(),
-              formattedTime: formatDateRange(slotStart, slotEnd)
+              formattedTime: formatDateRange(slotStart, slotEnd, 'fr-FR', timeZone)
             });
           }
         }
       }
     }
-    
-    // Passer au jour suivant
-    currentDate.setDate(currentDate.getDate() + 1);
-    currentDate.setHours(0, 0, 0, 0);
+
+    currentDate.setUTCDate(currentDate.getUTCDate() + 1);
   }
-  
+
   return slots;
 };
 
@@ -463,5 +466,5 @@ const serviceAccount = {
   token_uri: process.env.GOOGLE_TOKEN_URI || "https://oauth2.googleapis.com/token",
   auth_provider_x509_cert_url: process.env.GOOGLE_AUTH_PROVIDER_CERT_URL || "https://www.googleapis.com/oauth2/v1/certs",
   client_x509_cert_url: process.env.GOOGLE_CLIENT_CERT_URL || "",
-  universe_domain: "googleapis.com"
-}; 
+  universe_domain: "googleapis.com",
+};


### PR DESCRIPTION
## Summary
- handle timezone offset on a per-day basis
- generate slots from 9am to 5pm
- clean up service account config

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Declaration or statement expected)*