### PR TITLE
Fix appointment creation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ pnpm dev
 bun dev
 ```
 
+## Environment Variables
+
+The Google Calendar features require a service account or OAuth credentials. Create a `.env.local` file and provide the following variables:
+
+```bash
+GOOGLE_CLIENT_EMAIL=<service-account-email>
+GOOGLE_PRIVATE_KEY=<service-account-private-key>
+GOOGLE_PROJECT_ID=<google-project-id>
+
+# Optional OAuth configuration
+GOOGLE_CLIENT_ID=<oauth-client-id>
+GOOGLE_CLIENT_SECRET=<oauth-client-secret>
+GOOGLE_REDIRECT_URI=<oauth-redirect-uri>
+```
+
+Ensure the service account has access to the calendars that will receive meetings.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/app/api/google/create-event/route.ts
+++ b/app/api/google/create-event/route.ts
@@ -38,8 +38,8 @@ export async function POST(request: Request) {
       attendees,
       timeZone
     );
-    
-    return NextResponse.json(result);
+
+    return NextResponse.json({ success: true, event: result });
   } catch (error) {
     console.error('Erreur lors de la création de l\'événement:', error);
     return NextResponse.json({ 

--- a/app/availability/[departement]/page.tsx
+++ b/app/availability/[departement]/page.tsx
@@ -377,8 +377,8 @@ ${additionalInfo || "Aucune information complémentaire"}
       });
       
       const data = await response.json();
-      
-      if (data.success) {
+
+      if (response.ok && data.success) {
         // Afficher un message de confirmation
         alert(`Rendez-vous confirmé pour le ${selectedTimeSlot.formattedTime}.\n\nUn email de confirmation a été envoyé à ${userEmail}.`);
         


### PR DESCRIPTION
## Summary
- return success status from `create-event` API route
- verify API response when confirming appointments
- document environment variables for Google Calendar integration

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f35343aa88321bc230a678d3587cb